### PR TITLE
Add quizzes to the better to-do list

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -2049,7 +2049,7 @@ function renderProgressRings(container, scopedData) {
     const mode = getProgressRingMode();
     if (mode === "none") { container.innerHTML = ""; return; }
 
-    const allAssignments = scopedData.filter(item => (item.plannable_type == "assignment" || item.plannable_type == "planner_note"));
+    const allAssignments = scopedData.filter(item => (item.plannable_type == "assignment" || item.plannable_type == "planner_note" || item.plannable_type == "quiz"));
 
     const groups = {};
     allAssignments.forEach(item => {
@@ -2709,8 +2709,8 @@ async function createTodoSections(location) {
             });
 
         announcements = displayData.filter(item => item.plannable_type == "announcement");
-        assignmentsDue = displayData.filter(item => (item.plannable_type == "assignment" || item.plannable_type == "planner_note") && !item.submissions?.submitted && !item.planner_override?.marked_complete);
-        completed = displayData.filter(item => (item.plannable_type == "assignment" || item.plannable_type == "planner_note") && (item.submissions?.submitted || item.planner_override?.marked_complete));
+        assignmentsDue = displayData.filter(item => (item.plannable_type == "assignment" || item.plannable_type == "planner_note" || item.plannable_type == "quiz") && !item.submissions?.submitted && !item.planner_override?.marked_complete);
+        completed = displayData.filter(item => (item.plannable_type == "assignment" || item.plannable_type == "planner_note" || item.plannable_type == "quiz") && (item.submissions?.submitted || item.planner_override?.marked_complete));
         // The timeframe is a persisted Better Todo List sub-option set in the
         // popup. Read the current value each render so popup changes apply on
         // the next render. Keeps items due on/before now+range (overdue items


### PR DESCRIPTION
Two weeks into the semester and I nearly missed two quizzes because for some reason, the better to-do list didn't include them as a task.

Just the item type "quiz" was added in the three spots that mattered for the to-do list. I tested it by running the extension locally where the quizzes appeared, and then I went and took a quiz and it was moved to the "completed" section as expected. 

To be completely transparent, as simple as the solution was AI did help with this, but I understand the solution to the problem. Thanks for your work on this extension!